### PR TITLE
Spin regex matches too easily.

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function(){
 		.replace(/&:extend\((.*?)\)/g,"@extend $1")
 		.replace(/@extend\s*(.*?)\s*?all;/g,"@extend $1;")
 		//spin関数をadjust-hueに変換
-		.replace(/spin/g,'adjust-hue')
+		.replace(/([\W])spin\(/g,'$1adjust-hue(')
 		//~を除去
 		.replace(/~(\s*['"])/g,'$1')
 		//&が単語にくっついていたら話す


### PR DESCRIPTION
The `/spin/` regex matched too many places like class names, animation names etc. Here is the sample case that this pull request fixes.

``` less
.myspin(mycolor){
    color: spin(mycolor, 50%);
}

.spin,
.coolspin,
.awesome-spin,
.spinner {
  animation: spin 1s linear infinite;
  color: spin(hsl(10, 90%, 50%), 30);
  color:spin(hsl(10, 90%, 50%), 30);
  border-color: spin(hsl(10, 90%, 50%), 0)spin(hsl(10, 90%, 50%), 10)   spin(hsl(10, 90%, 50%), 20) spin(hsl(10, 90%, 50%), 30)
}

@keyframes spin {
  to {
    transform: rotate(360deg);
  }
}
```
