### PR TITLE
Conversion adds extra spaces before ampersands

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = function(){
 		//~を除去
 		.replace(/~(\s*['"])/g,'$1')
 		//&が単語にくっついていたら話す
-		.replace(/(.[\w\-]*?)&/g,"$1 &")
+		.replace(/(.[\w\-]+?)&/g,"$1 &")
 		//namespaceを定義
 		.replace(/#([\w\-]*)\s*\{([^\}]*@mixin[\s\S]*)\}/g,function(all,$1,$2){
 			all = all.replace(/#[\w\-]*\s*\{([^\}]*@mixin[\s\S]*)\}/,"$1");


### PR DESCRIPTION
This code is converted so that it has extra space before the ampersand `&`. That's because the regular expression is too liberal on matching and matches also zero characters.

``` less
.example {
  color: red;
  &:hover {
    color: blue;
  }
}
```

Produces this result:

``` scss
.example {
  color: red;
   &:hover {
    color: blue;
  }
}
```

With this fix from `*` to `+` I got better results and the ampersands were not misaligned. We use [stylelint](stylelint.io) to complain about these things and keep our code neat. That's how I spotted these and why it annoyed me. :)
