### PR TITLE
Added support for converting LESS fade function

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,8 @@ module.exports = function(){
 		.replace(/@extend\s*(.*?)\s*?all;/g,"@extend $1;")
 		//spin関数をadjust-hueに変換
 		.replace(/([\W])spin\(/g,'$1adjust-hue(')
+		.replace(/(\W)fade\(([^)]+?)% *\)/g,'$1rgba($2%/100.0%)')
+		.replace(/(\W)fade\(/g,'$1rgba(')
 		//~を除去
 		.replace(/~(\s*['"])/g,'$1')
 		//&が単語にくっついていたら話す


### PR DESCRIPTION
The LESS `fade(@mycolor, 50%)` function sets the opacity of an color to a specific value, percentage is supported. Our code had this in a few places. The matching code in SCSS is `rgba($color, 0.5)` and it does not support percentages. So I did a quick hack to convert the less code with percentages to `rgba($mycolor, 50%/100.0%)`. This way the conversion can be automated and it works in SCSS too.

I also added a basic match after that so that non percentage values do get converted too.
