### PR TITLE
add support for multiple & in a row

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,9 @@ module.exports = function(){
 		})
 		//namespaceをinclude
 		.replace(/#([\w\-]*)\s*>\s@include\s([\w\-]*)\((.*)\);/g,"@include $1_$2($3);")
+		//handle multiple & in a row
+		.replace(/&(&+)/g, function(match, p1){return "&" + p1.replace(/&/g,"#{&}")});
+
 		file.contents = new Buffer(content);
 		file.path = ext(file.path, '.scss'); 
 		this.push(file);


### PR DESCRIPTION
The syntax for sass for handling repeated parent selectors is different from less. In less you can just do &&&& as many times as you want, but in sass after the first & you have to do it like &#{&}#{&} so I added a line that handles that 
